### PR TITLE
create user/add user object model for post request

### DIFF
--- a/create-user/src/api/fetchRewards.ts
+++ b/create-user/src/api/fetchRewards.ts
@@ -1,4 +1,4 @@
-import FetchRewardsType from "../model/fetchRewards";
+import FetchRewardsType, { User } from "../model/fetchRewards";
 
 const FETCH_REWARDS_ENDPOINT =
   "https://frontend-take-home.fetchrewards.com/form";
@@ -19,26 +19,14 @@ const getDataForForm = (): Promise<FetchRewardsType> => {
   });
 };
 
-const submitUserData = (
-  name: string,
-  email: string,
-  password: string,
-  occupation: string,
-  state: string
-): Promise<void> => {
+const submitUserData = (user: User): Promise<void> => {
   const requestInfo = {
     method: "POST",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      name: name,
-      email: email,
-      password: password,
-      occupation: occupation,
-      state: state,
-    }),
+    body: JSON.stringify(user),
   };
 
   return new Promise((resolve, reject) => {

--- a/create-user/src/components/CreateUserComponent.tsx
+++ b/create-user/src/components/CreateUserComponent.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mui/material";
 import CommonSelectComponent from "./CommonSelectComponent";
 import FetchRewards from "../api/fetchRewards";
-import FetchRewardsType from "../model/fetchRewards";
+import FetchRewardsType, { User } from "../model/fetchRewards";
 import CreateUserFooterComponent from "./CreateUserFooterComponent";
 
 /**
@@ -87,14 +87,16 @@ const CreateUserComponent: FC<unknown> = () => {
       return;
     }
 
+    const newUser: User = {
+      name: `${firstName.toString()} ${lastName.toString()}`,
+      email: email.toString(),
+      password: password.toString(),
+      occupation: occupation.toString(),
+      state: state.toString()
+    };
+
     setIsLoaded(false);
-    FetchRewards.submitUserData(
-      `${firstName.toString()} ${lastName.toString()}`,
-      email.toString(),
-      password.toString(),
-      occupation.toString(),
-      state.toString()
-    ).then(
+    FetchRewards.submitUserData(newUser).then(
       () => {
         // success
         setSuccess("You have successfully submitted the form!");

--- a/create-user/src/components/CreateUserComponent.tsx
+++ b/create-user/src/components/CreateUserComponent.tsx
@@ -92,7 +92,7 @@ const CreateUserComponent: FC<unknown> = () => {
       email: email.toString(),
       password: password.toString(),
       occupation: occupation.toString(),
-      state: state.toString()
+      state: state.toString(),
     };
 
     setIsLoaded(false);

--- a/create-user/src/model/fetchRewards.ts
+++ b/create-user/src/model/fetchRewards.ts
@@ -1,3 +1,12 @@
+// represents the user object sent via POST to fetch rewards endpoint from form data submitted by the user
+export type User = {
+  name: string;
+  email: string;
+  password: string;
+  occupation: string;
+  state: string;
+};
+
 // represents the array of state names and state abbreviations returned from GET request
 export type State = {
   name: string;


### PR DESCRIPTION
This PR adds a new `User` object model to be used with the `POST` request to the _Fetch Rewards_ endpoint, also changed the POST method in `/api/` to use this new model instead of taking in all of the required parameters.